### PR TITLE
TS-developed changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-This is a README
+This is a pre-release version of the VS Code plugin for CxSAST.  We are not yet ready to publicly announce it yet; this is a preliminary version intended for our design partners.
+
+This software is not (yet) supported by Checkmarx.  Download and install at your own risk.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "cxvscode",
 	"displayName": "CxCode",
 	"description": "VSCode extension to enable scan and view on Checkmarx",
-	"version": "2020.2.6-WRK",
+	"version": "2020.2.6-TS",
 	"publisher": "Checkmarx",
 	"icon": "resources/icons/Checkmarx.png",
 	"license": "SEE LICENSE IN checkmarx-license-terms.md",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
 	"name": "cxvscode",
 	"displayName": "CxCode",
 	"description": "VSCode extension to enable scan and view on Checkmarx",
-	"version": "2020.2.6",
-	"publisher": "ghannamz",
+	"version": "2020.2.6-WRK",
+	"publisher": "Checkmarx",
 	"icon": "resources/icons/Checkmarx.png",
 	"license": "SEE LICENSE IN checkmarx-license-terms.md",
 	"repository": {
@@ -134,6 +134,30 @@
 				}
 			},
 			{
+				"command": "Explorer.scanFile",
+				"title": "Scan Current File",
+				"icon": {
+					"light": "resources/icons/light/new-file.svg",
+					"dark": "resources/icons/dark/new-file.svg"
+				}
+			},
+			{
+				"command": "Explorer.scanFolder",
+				"title": "Scan Current Folder",
+				"icon": {
+					"light": "resources/icons/light/new-folder.svg",
+					"dark": "resources/icons/dark/new-folder.svg"
+				}
+			},
+			{
+				"command": "Explorer.scanWorkspace",
+				"title": "Scan Workspace",
+				"icon": {
+					"light": "resources/icons/light/new-folder.svg",
+					"dark": "resources/icons/dark/new-folder.svg"
+				}
+			},
+			{
 				"command": "cxportalwin.bindProject",
 				"title": "Bind Project",
 				"icon": {
@@ -255,6 +279,23 @@
 					"command": "cxscanswin.showQueryDescription",
 					"when": "view == cxscanswin && viewItem == query_node",
 					"group": "inline"
+				}
+			],
+			"explorer/context": [
+				{
+					"command": "Explorer.scanFolder",
+					"when": "explorerResourceIsFolder",
+					"group": "Cx"
+				},
+				{
+					"command": "Explorer.scanFile",
+					"when": "!explorerResourceIsFolder",
+					"group": "Cx"
+				},
+				{
+					"command": "Explorer.scanWorkspace",
+					"when": "workspaceFolderCount != 0",
+					"group": "Cx"
 				}
 			]
 		}

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
 			},
 			{
 				"command": "cxportalwin.scanFile",
-				"title": "Scan File",
+				"title": "Scan Any File",
 				"icon": {
 					"light": "resources/icons/light/new-file.svg",
 					"dark": "resources/icons/dark/new-file.svg"
@@ -127,7 +127,7 @@
 			},
 			{
 				"command": "cxportalwin.scanFolder",
-				"title": "Scan Folder",
+				"title": "Scan Any Folder",
 				"icon": {
 					"light": "resources/icons/light/new-folder.svg",
 					"dark": "resources/icons/dark/new-folder.svg"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { ScanNode } from './model/ScanNode';
 
 export function activate(context: vscode.ExtensionContext) {
 	if (context && context.subscriptions && context.subscriptions.length > 0) {
-		context.subscriptions.forEach(item => item.dispose());
+		context.subscriptions.forEach((item: { dispose: () => any; }) => item.dispose());
 		context.subscriptions.splice(0);
 	}
 
@@ -42,14 +42,38 @@ export function activate(context: vscode.ExtensionContext) {
 		cxTreeDataProvider.refresh(serverNode);
 	}));
 	context.subscriptions.push(vscode.commands.registerCommand("cxportalwin.scanFile", async (serverNode: ServerNode) => {
-		await serverNode.scan(currProjectToScan, false, 'Open Source File');
+		await serverNode.scan(currProjectToScan, false, '');
 		cxTreeDataProvider.refresh(serverNode);
 		serverNode.displayCurrentScanedSource();
 	}));
 	context.subscriptions.push(vscode.commands.registerCommand("cxportalwin.scanFolder", async (serverNode: ServerNode) => {
-		await serverNode.scan(currProjectToScan, true, 'Open Source Folder');
+		await serverNode.scan(currProjectToScan, true, '');
 		cxTreeDataProvider.refresh(serverNode);
 		serverNode.displayCurrentScanedSource();
+	}));
+	context.subscriptions.push(vscode.commands.registerCommand("Explorer.scanFile", async (uri:vscode.Uri) => {
+		let cxServerNode = cxTreeDataProvider.getCurrentServerNode();
+		if(cxServerNode) {
+			await cxServerNode.scan(currProjectToScan, false, uri.fsPath);
+			cxTreeDataProvider.refresh(cxServerNode);
+			cxServerNode.displayCurrentScanedSource();
+		}
+	}));
+	context.subscriptions.push(vscode.commands.registerCommand("Explorer.scanFolder", async (uri:vscode.Uri) => {
+		let cxServerNode = cxTreeDataProvider.getCurrentServerNode();
+		if(cxServerNode) {
+			await cxServerNode.scan(currProjectToScan, true, uri.fsPath);
+			cxTreeDataProvider.refresh(cxServerNode);
+			cxServerNode.displayCurrentScanedSource();
+		}
+	}));
+	context.subscriptions.push(vscode.commands.registerCommand("Explorer.scanWorkspace", async () => {
+		let cxServerNode = cxTreeDataProvider.getCurrentServerNode();
+		if(cxServerNode && vscode.workspace.rootPath) {
+			await cxServerNode.scan(currProjectToScan, true, vscode.workspace.rootPath);
+			cxTreeDataProvider.refresh(cxServerNode);
+			cxServerNode.displayCurrentScanedSource();
+		}
 	}));
 	context.subscriptions.push(vscode.commands.registerCommand("cxportalwin.bindProject", async (serverNode: ServerNode) => {
 		const chosenProject = await serverNode.bindProject();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,9 @@ export function activate(context: vscode.ExtensionContext) {
 		context.subscriptions.splice(0);
 	}
 
-	const numOfContextSubsForCxPortalWin: number = 13;
+	// keep the count of command registered at initialization; everything above it is results, and will need to be refreshed 
+	let numOfContextSubsForCxPortalWin: number = 0;
+
 	const checkmarxOutput: vscode.OutputChannel = vscode.window.createOutputChannel('Checkmarx');
 	context.subscriptions.push(checkmarxOutput);
 
@@ -90,6 +92,7 @@ export function activate(context: vscode.ExtensionContext) {
 	}));
 	context.subscriptions.push(vscode.commands.registerCommand("cxportalwin.retrieveScanResults", async (scanNode: ScanNode) => {
 		if (scanNode.canRetrieveResults()) {
+			// remove any entries that contain (potentially stale) results
 			if (context.subscriptions.length > numOfContextSubsForCxPortalWin) {
 				for (let idx = numOfContextSubsForCxPortalWin; idx < context.subscriptions.length; idx++) {
 					context.subscriptions[idx].dispose();
@@ -102,6 +105,9 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.window.showErrorMessage('Access token expired. Please login.');
 		}
 	}));
+
+	// record the number of registered commands
+	numOfContextSubsForCxPortalWin = context.subscriptions.length;
 	if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Checkmarx Extension Enabled!'); }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { CxTreeDataProvider } from "./model/CxTreeDataProvider";
 import { ServerNode } from './model/ServerNode';
 import { ProjectNode } from './model/ProjectNode';
 import { ScanNode } from './model/ScanNode';
+import { CxSettings } from "./services/CxSettings";
 
 export function activate(context: vscode.ExtensionContext) {
 	if (context && context.subscriptions && context.subscriptions.length > 0) {
@@ -101,7 +102,7 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.window.showErrorMessage('Access token expired. Please login.');
 		}
 	}));
-	vscode.window.showInformationMessage('Checkmarx Extension Enabled!');
+	if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Checkmarx Extension Enabled!'); }
 }
 
 export function deactivate() { }

--- a/src/model/CxTreeDataProvider.ts
+++ b/src/model/CxTreeDataProvider.ts
@@ -1,13 +1,13 @@
 import * as vscode from "vscode";
 import { INode } from "../interface/INode";
 import { ServerNode } from "./ServerNode";
-import { ScanNode } from './ScanNode'
+import { ScanNode } from './ScanNode';
 import { CxSettings } from "../services/CxSettings";
 import { Logger } from "@checkmarx/cx-common-js-client";
 import { ConsoleLogger } from "../services/consoleLogger";
-import { CxTreeScans } from './CxTreeScans'
-import { WebViews } from "../services/WebViews"
-import { QueryNode } from './QueryNode'
+import { CxTreeScans } from './CxTreeScans';
+import { WebViews } from "../services/WebViews";
+import { QueryNode } from './QueryNode';
 
 export class CxTreeDataProvider implements vscode.TreeDataProvider<INode> {
     public _onDidChangeTreeData: vscode.EventEmitter<INode> = new vscode.EventEmitter<INode>();
@@ -103,5 +103,18 @@ export class CxTreeDataProvider implements vscode.TreeDataProvider<INode> {
         context.subscriptions.push(vscode.commands.registerCommand("cxscanswin.showQueryDescription", async (queryNode: QueryNode) => {
             await WebViews.webViews.createQueryDescriptionWebView(queryNode.query?.$.id);
         }));
+    }
+
+    /**
+     * TODO: Change to return the currently selected ServerNode, once support for multiple servers is added.
+     * @returns Top ServerNode or undefined if none has been configured
+     */
+    public getCurrentServerNode() {
+        if(this.serverNodes && this.serverNodes.length > 0) {
+            return this.serverNodes[0] as ServerNode;
+        }
+        else {
+            return undefined;
+        }
     }
 }

--- a/src/model/CxTreeDataProvider.ts
+++ b/src/model/CxTreeDataProvider.ts
@@ -38,12 +38,12 @@ export class CxTreeDataProvider implements vscode.TreeDataProvider<INode> {
             if (this.serverNodes.length > 0 && this.serverNodes[0].sastUrl === cxServer['url']) {
                 await CxSettings.setServer();
                 this.refresh();
-                vscode.window.showInformationMessage('Server node edited');
+                if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Server node edited'); }
             } else if (this.serverNodes.length > 0 && this.serverNodes[0].sastUrl !== cxServer['url']) {
                 this.refresh();
-                vscode.window.showInformationMessage('Server node edited');
+                if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Server node edited'); }
             } else {
-                vscode.window.showErrorMessage('Server node cannot be edited. It must be added first.');
+                if(!CxSettings.isQuiet()) { vscode.window.showErrorMessage('Server node cannot be edited. It must be added first.'); }
             }
         } catch (err) {
             this.log.error(err);

--- a/src/model/ScanNode.ts
+++ b/src/model/ScanNode.ts
@@ -1,14 +1,14 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { INode } from "../interface/INode";
-import { ServerNode } from './ServerNode'
+import { ServerNode } from './ServerNode';
 import { HttpClient } from "@checkmarx/cx-common-js-client";
 import { CxSettings } from "../services/CxSettings";
 import { ScanResults } from "@checkmarx/cx-common-js-client";
 import { Logger } from "@checkmarx/cx-common-js-client";
 import { ReportingClient } from "@checkmarx/cx-common-js-client";
 import { Utility } from "../utils/util";
-import { SeverityNode } from './SeverityNode'
+import { SeverityNode } from './SeverityNode';
 import * as fs from "fs";
 import * as url from "url";
 
@@ -30,7 +30,7 @@ export class ScanNode implements INode {
         if (result.includes(workspace)) {
             result = result.replace(workspace, '');
             if (result.length === 0) {
-                result = "TheEntireProject";
+                result = "Workspace";
             }
             if (result.startsWith(path.sep)) {
                 result = result.replace(path.sep, '');

--- a/src/model/ScanNode.ts
+++ b/src/model/ScanNode.ts
@@ -30,7 +30,7 @@ export class ScanNode implements INode {
         if (result.includes(workspace)) {
             result = result.replace(workspace, '');
             if (result.length === 0) {
-                result = "Workspace";
+                result = "Workplace";
             }
             if (result.startsWith(path.sep)) {
                 result = result.replace(path.sep, '');
@@ -140,7 +140,7 @@ Scan results location:  ${this.scanResult.sastScanResultsLink}
 
     private async addDetailedReportToScanResults() {
         const client = new ReportingClient(this.httpClient, this.log);
-        vscode.window.showInformationMessage('Waiting for server to generate scan report');
+        this.log.info('Waiting for server to generate scan report');
         const reportXml = await client.generateReport(this.scanId, undefined);
         const doc = reportXml.CxXMLResults;
         this.scanResult.scanStart = doc.$.ScanStart;
@@ -149,7 +149,7 @@ Scan results location:  ${this.scanResult.sastScanResultsLink}
         this.scanResult.filesScanned = doc.$.FilesScanned;
         this.queries = doc.Query;
         this.scanResult.queryList = ScanNode.toJsonQueries(doc.Query);
-        vscode.window.showInformationMessage('Scan report was generated successfully');
+        if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Scan report was generated successfully'); }
     }
 
     private static toJsonQueries(queries: any[] | undefined) {
@@ -180,7 +180,7 @@ Scan results location:  ${this.scanResult.sastScanResultsLink}
         const reportJson = JSON.stringify(this.scanResult);
 
         this.log.info(`Writing report to ${jsonReportPath}`);
-        vscode.window.showInformationMessage(`Writing report to ${jsonReportPath}`);
+        if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage(`Writing report to ${jsonReportPath}`); }
         await new Promise((resolve, reject) => {
             fs.writeFile(jsonReportPath, reportJson, err => {
                 if (err) {
@@ -192,7 +192,7 @@ Scan results location:  ${this.scanResult.sastScanResultsLink}
         });
 
         this.log.info('Generated Checkmarx summary results.');
-        vscode.window.showInformationMessage('Generated Checkmarx summary results.');
+        if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Generated Checkmarx summary results.'); }
 
         if (cxServer['reportpath'] !== jsonReportPath) {
             cxServer['reportpath'] = jsonReportPath;

--- a/src/model/ServerNode.ts
+++ b/src/model/ServerNode.ts
@@ -313,7 +313,7 @@ File extensions: ${formatOptionalString(config.fileExtension)}
     }
 
     private addSource(sourceLocation: string, scanId: number, projectId: number, isFolder: boolean) {
-        const newSource: ScanNode = new ScanNode(scanId, projectId, sourceLocation, isFolder, this.httpClient, this.log, this)
+        const newSource: ScanNode = new ScanNode(scanId, projectId, sourceLocation, isFolder, this.httpClient, this.log, this);
         let found: boolean = false;
         for (const source of this.scanedSources) {
             if (this.isEquivalent(newSource, source)) {
@@ -351,7 +351,12 @@ File extensions: ${formatOptionalString(config.fileExtension)}
         }
     }
 
-    public async scan(projectNode: ProjectNode, isFolder: boolean, labelType: string) {
+    /**
+     * @param projectNode  CxSAST project, or undefined if this workspace not yet bound to a project
+     * @param isFolder True if scanning a folder; false if scanning a single file
+     * @param scanPath Path to a file or a folder to be scanned; empty string will prompt user to select 
+     */
+    public async scan(projectNode: ProjectNode, isFolder: boolean, scanPath: string) {
         try {
             if (!this.httpClient.accessToken) {
                 throw Error('Access token expired. Please login.');
@@ -379,9 +384,17 @@ File extensions: ${formatOptionalString(config.fileExtension)}
                 presetName = await this.choosePreset();
             }
 
-            const sourceLocation: string = await this.selectSourceLocation(isFolder, labelType);
+            // get the source location; if scanPath is empty, prompt user to select
+            let sourceLocation: string;
+            if(!scanPath || scanPath.length === 0) {
+                const labelType : string = (isFolder) ? 'Scan Folder' : 'Scan File';
+                sourceLocation = await this.selectSourceLocation(isFolder, labelType);
+            }
+            else {
+                sourceLocation = scanPath;
+            }
 
-            const isScanIncremental = await Utility.showInputBox("Is scan incremental? (y/n)", false, "y");
+            const isScanIncremental = await Utility.showPickString("Is scan incremental?", ['Yes', 'No']);
             const isIncremental: boolean = Utility.modeIsEnabled(isScanIncremental);
             if (isIncremental) {
                 vscode.window.showInformationMessage('Scan is incremental');
@@ -389,7 +402,7 @@ File extensions: ${formatOptionalString(config.fileExtension)}
                 vscode.window.showInformationMessage('Scan is full');
             }
 
-            const isScanPrivate = await Utility.showInputBox("Is scan private? (y/n)", false, "y");
+            const isScanPrivate = await Utility.showPickString("Is scan private?", ['Yes', 'No']);
             const isPrivate: boolean = Utility.modeIsEnabled(isScanPrivate);
             if (isPrivate) {
                 vscode.window.showInformationMessage('Scan is private');

--- a/src/model/ServerNode.ts
+++ b/src/model/ServerNode.ts
@@ -127,7 +127,7 @@ File extensions: ${formatOptionalString(config.fileExtension)}
             }
             await this.httpClient.login(this.username, this.password);
             this.log.info('Login successful');
-            vscode.window.showInformationMessage('Login successful');
+            if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Login successful'); }
             if (!cxServer['username'] && !cxServer['password']) {
                 cxServer['username'] = this.username;
                 cxServer['password'] = this.password;
@@ -146,7 +146,7 @@ File extensions: ${formatOptionalString(config.fileExtension)}
             return;
         }
         this.httpClient.logout();
-        vscode.window.showInformationMessage('Logout successful');
+        if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Logout successful'); }
         const cxServer = await CxSettings.getServer();
         cxServer['username'] = undefined;
         cxServer['password'] = undefined;
@@ -193,7 +193,7 @@ File extensions: ${formatOptionalString(config.fileExtension)}
         return new Promise<string>(async (resolve) => {
             await vscode.window.showQuickPick(allPresetNames, { placeHolder: 'Choose Preset Name' }).then((preset) => {
                 if (preset) {
-                    vscode.window.showInformationMessage('Chosen Preset: ' + preset);
+                    if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Chosen Preset: ' + preset); }
                     resolve(preset);
                 }
             });
@@ -207,7 +207,7 @@ File extensions: ${formatOptionalString(config.fileExtension)}
         return new Promise<string>(async (resolve) => {
             await vscode.window.showQuickPick(allTeamNames, { placeHolder: 'Choose Team Path' }).then((team) => {
                 if (team) {
-                    vscode.window.showInformationMessage('Chosen Team: ' + team);
+                    if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Chosen Team: ' + team); }
                     resolve(team);
                 }
             });
@@ -226,7 +226,7 @@ File extensions: ${formatOptionalString(config.fileExtension)}
         return new Promise<string>(async (resolve) => {
             await vscode.window.showOpenDialog(options).then((fileUri) => {
                 if (fileUri && fileUri[0]) {
-                    vscode.window.showInformationMessage('Selected source: ' + fileUri[0].fsPath);
+                    if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Selected source: ' + fileUri[0].fsPath); }
                     resolve(fileUri[0].fsPath);
                 }
             });
@@ -280,7 +280,7 @@ File extensions: ${formatOptionalString(config.fileExtension)}
                 const [teamsById, teamsByName] = await this.getAllTeams();
                 chosenProject = await this.chooseProjectToBind(projectList, teamsById);
                 if (chosenProject) {
-                    vscode.window.showInformationMessage('Chosen: ' + chosenProject.label + ', ' + chosenProject.detail);
+                    if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Chosen: ' + chosenProject.label + ', ' + chosenProject.detail); }
                     chosenProject.label = chosenProject.label.replace("project: ", '');
                     chosenProject.detail = chosenProject.detail?.replace("team: ", '');
                     const boundProject: any = projectList.find(project => project['name'] === chosenProject?.label && project['teamId'] === teamsByName.get(chosenProject?.detail || ''));
@@ -289,7 +289,7 @@ File extensions: ${formatOptionalString(config.fileExtension)}
                     }
                 }
             } else {
-                vscode.window.showErrorMessage('There are no projects to bind.');
+                vscode.window.showErrorMessage('There are no projects to bind to.');
             }
         } catch (err) {
             this.log.error(err);
@@ -378,7 +378,7 @@ File extensions: ${formatOptionalString(config.fileExtension)}
             }
             else {
                 this.projectName = await Utility.showInputBox("Enter project name", false);
-                vscode.window.showInformationMessage('Chosen Project: ' + this.projectName);
+                if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Chosen Project: ' + this.projectName); }
                 this.teamPath = await this.chooseTeam();
                 await this.isProjectExists();
                 presetName = await this.choosePreset();
@@ -396,18 +396,22 @@ File extensions: ${formatOptionalString(config.fileExtension)}
 
             const isScanIncremental = await Utility.showPickString("Is scan incremental?", ['Yes', 'No']);
             const isIncremental: boolean = Utility.modeIsEnabled(isScanIncremental);
-            if (isIncremental) {
-                vscode.window.showInformationMessage('Scan is incremental');
-            } else {
-                vscode.window.showInformationMessage('Scan is full');
+            if(!CxSettings.isQuiet()) {
+                if (isIncremental) {
+                    vscode.window.showInformationMessage('Scan is incremental');
+                } else {
+                    vscode.window.showInformationMessage('Scan is full');
+                }
             }
 
             const isScanPrivate = await Utility.showPickString("Is scan private?", ['Yes', 'No']);
             const isPrivate: boolean = Utility.modeIsEnabled(isScanPrivate);
-            if (isPrivate) {
-                vscode.window.showInformationMessage('Scan is private');
-            } else {
-                vscode.window.showInformationMessage('Scan is public');
+            if(!CxSettings.isQuiet()) {
+                if (isPrivate) {
+                    vscode.window.showInformationMessage('Scan is private');
+                } else {
+                    vscode.window.showInformationMessage('Scan is public');
+                }
             }
 
             const config: ScanConfig = {

--- a/src/model/ServerNode.ts
+++ b/src/model/ServerNode.ts
@@ -33,7 +33,7 @@ export class ServerNode implements INode {
         this.password = '';
         const workspaceFolders = vscode.workspace.workspaceFolders;
         this.workspaceFolder = workspaceFolders ? workspaceFolders[0].uri : undefined;
-        this.folderExclusion = "cvs, .svn, .hg, .git, .bzr, bin, obj, backup, .idea";
+        this.folderExclusion = "cvs, .svn, .hg, .git, .bzr, bin, obj, backup, .idea, .vscode, node_modules";
         this.fileExtension = "!*.DS_Store, !*.ipr, !*.iws, !*.bak, !*.tmp, !*.aac, !*.aif, !*.iff, !*.m3u, !*.mid, !*.mp3, !*.mpa, !*.ra, !*.wav, !*.wma, !*.3g2, !*.3gp, !*.asf, !*.asx, !*.avi, !*.flv, !*.mov, !*.mp4, !*.mpg, !*.rm, !*.swf, !*.vob, !*.wmv, !*.bmp, !*.gif, !*.jpg, !*.png, !*.psd, !*.tif, !*.swf, !*.jar, !*.zip, !*.rar, !*.exe, !*.dll, !*.pdb, !*.7z, !*.gz, !*.tar.gz, !*.tar, !*.gz, !*.ahtm, !*.ahtml, !*.fhtml, !*.hdm, !*.hdml, !*.hsql, !*.ht, !*.hta, !*.htc, !*.htd, !*.war, !*.ear, !*.htmls, !*.ihtml, !*.mht, !*.mhtm, !*.mhtml, !*.ssi, !*.stm, !*.stml, !*.ttml, !*.txn, !*.xhtm, !*.xhtml, !*.class, !*.iml";
         const baseUrl = url.resolve(this.sastUrl, 'CxRestAPI/');
         this.httpClient = new HttpClient(baseUrl, "Visual Studio Code", this.log);

--- a/src/services/CxSettings.ts
+++ b/src/services/CxSettings.ts
@@ -25,4 +25,19 @@ export class CxSettings {
         const serverNode: any = await vscode.workspace.getConfiguration().get("cx.server");
         return serverNode;
     }
+
+    /**
+     * Returns value of the cx.quiet setting.  The setting controls the amount of popup messages displayed to the user.
+     * Add "cx.quiet" : "true" to the settings.json
+     * @returns Value of cx.quiet setting
+     */
+    public static isQuiet(): boolean {
+        const isQuietSetting : string = vscode.workspace.getConfiguration().get("cx.quiet") as string;
+        if(isQuietSetting && isQuietSetting.trim().toLowerCase() === 'true') {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
 }

--- a/src/services/WebViews.ts
+++ b/src/services/WebViews.ts
@@ -26,7 +26,7 @@ export class WebViews {
 			this.queryDescriptionPanel.dispose();
 		}
 
-		vscode.window.showInformationMessage('Loading the HTML content...');
+		this.log.info('Loading the HTML content...');
 
 		const codeBashing: any = await this.httpClient.getRequest(`Queries/${queryId}/AppSecCoachLessonsRequestData`);
 		const codeBashingLink: string = codeBashing.url + '?serviceProviderId=' + codeBashing.paramteres.serviceProviderId
@@ -151,7 +151,7 @@ export class WebViews {
 			]
 		});
 		this.createAttackVectorWebView(context);
-		this.createResultTableWebView(context)
+		this.createResultTableWebView(context);
 	}
 
 	destroyWebViews() {

--- a/src/services/sastClient.ts
+++ b/src/services/sastClient.ts
@@ -65,13 +65,13 @@ export class SastClient {
                     }
                 });
         });
-    };
+    }
 
     private logWaitingProgress = (scanStatus: ScanStatus) => {
         const stage = scanStatus && scanStatus.stage ? scanStatus.stage.value : 'n/a';
         this.log.info(`Waiting for SAST scan results. ${scanStatus.totalPercent}% processed. Status: ${stage}.`);
         vscode.window.showInformationMessage(`Waiting for SAST scan results. ${scanStatus.totalPercent}% processed. Status: ${stage}.`);
-    };
+    }
 
     private static isFinishedSuccessfully(status: ScanStatus) {
         return status && status.stage &&

--- a/src/services/sastClient.ts
+++ b/src/services/sastClient.ts
@@ -5,6 +5,7 @@ import { ScanStage } from "@checkmarx/cx-common-js-client";
 import { Waiter } from "@checkmarx/cx-common-js-client";
 import { Logger } from "@checkmarx/cx-common-js-client";
 import { PollingSettings } from "@checkmarx/cx-common-js-client";
+import { CxSettings } from "../services/CxSettings";
 
 export class SastClient {
     private static readonly POLLING_INTERVAL_IN_SECONDS = 10;
@@ -19,7 +20,7 @@ export class SastClient {
 
     async waitForScanToFinish() {
         this.log.info('Waiting for CxSAST scan to finish.');
-        vscode.window.showInformationMessage('Waiting for CxSAST scan to finish.');
+        if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('Waiting for CxSAST scan to finish.'); }
 
         const polling: PollingSettings = {
             masterTimeoutMinutes: this.scanTimeoutInMinutes,
@@ -39,7 +40,7 @@ export class SastClient {
 
         if (SastClient.isFinishedSuccessfully(lastStatus)) {
             this.log.info('SAST scan finished successfully.');
-            vscode.window.showInformationMessage('SAST scan finished successfully.');
+            if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage('SAST scan finished successfully.'); }
         } else {
             SastClient.throwScanError(lastStatus);
         }
@@ -70,7 +71,7 @@ export class SastClient {
     private logWaitingProgress = (scanStatus: ScanStatus) => {
         const stage = scanStatus && scanStatus.stage ? scanStatus.stage.value : 'n/a';
         this.log.info(`Waiting for SAST scan results. ${scanStatus.totalPercent}% processed. Status: ${stage}.`);
-        vscode.window.showInformationMessage(`Waiting for SAST scan results. ${scanStatus.totalPercent}% processed. Status: ${stage}.`);
+        if(!CxSettings.isQuiet()) { vscode.window.showInformationMessage(`Waiting for SAST scan results. ${scanStatus.totalPercent}% processed. Status: ${stage}.`); }
     }
 
     private static isFinishedSuccessfully(status: ScanStatus) {

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -6,7 +6,7 @@ export class Utility {
     }
 
     public static modeIsEnabled(mode: string): boolean {
-        if (mode && mode.trim().toLowerCase() === "y") {
+        if (mode && mode.trim().toLowerCase().charAt(0) === 'y') {
             return true;
         }
         return false;
@@ -20,6 +20,26 @@ export class Utility {
         };
         return new Promise<string>(async (resolve) => {
             await vscode.window.showInputBox(options).then((input) => {
+                if (input) {
+                    resolve(input);
+                }
+            });
+        });
+    }
+
+    /**
+     * Gets user input from a list of options.  First option is always selected by default.
+     * @param prompt Prompt to display 
+     * @param items Array of srtings with options
+     * @returns Selected option as String
+     */
+    public static async showPickString(prompt: string, items: string[]) : Promise<string> {
+        const options: vscode.QuickPickOptions = {
+            placeHolder: prompt,
+            canPickMany: false
+          };
+        return new Promise<string>(async (resolve) => {
+            await vscode.window.showQuickPick(items, options).then((input) => {
                 if (input) {
                     resolve(input);
                 }


### PR DESCRIPTION
- Added context-sensitive menus to the file explorer inside VSC to scan the currently selected file or folder, or scan the entire workspace.  Renamed the original commands "Scan Any File" and "Scan Any Folder". 
- 	Added .vscode and node_modules to the default exclusions list 
- 	Added an unpublished setting, cx.quiet.  If added (manually) to the settings.json, it stops most informational popups, like progress reports while scan is running, since you can see them (and more!) in the Checkmarx output window.  It is not enabled by default, so if you don't add the settings you will see the same behavior as before.
- 	Made a few minor changes, like switching yes/no questions to a pick list.