### PR TITLE
Fixed #6 - Scan results not visible on Linux and macOS

### DIFF
--- a/src/services/CxSettings.ts
+++ b/src/services/CxSettings.ts
@@ -131,7 +131,7 @@ export class CxSettings {
      */
     public static getServer(): CxServerSettings {
         const serverSettings: CxServerSettings = vscode.workspace.getConfiguration().get(CXSERVER) as CxServerSettings;
-        if(serverSettings.password.length > 0) {
+        if(serverSettings && serverSettings.password && serverSettings.password.length > 0) {
             serverSettings.password = Utility.decryptPassword(serverSettings.username, serverSettings.password);
         }
         return serverSettings;

--- a/src/services/WebViews.ts
+++ b/src/services/WebViews.ts
@@ -68,10 +68,7 @@ export class WebViews {
 		);
 
 		try {
-			const onDiskPath = vscode.Uri.file(path.join(context.extensionPath, 'attackVectorWebView.html'));
-			let attackVectorViewPath = decodeURIComponent(onDiskPath.toString());
-			attackVectorViewPath = attackVectorViewPath.substring(attackVectorViewPath.indexOf("c:/"));
-
+			const attackVectorViewPath:string = path.join(context.extensionPath, 'attackVectorWebView.html');
 			fs.readFile(attackVectorViewPath, "utf8",
 				(err: any, data: any) => {
 					if (this.attackVectorPanel) {
@@ -110,10 +107,7 @@ export class WebViews {
 		);
 
 		try {
-			const onDiskPath = vscode.Uri.file(path.join(context.extensionPath, 'resultTableWebView.html'));
-			let resultTableViewPath = decodeURIComponent(onDiskPath.toString());
-			resultTableViewPath = resultTableViewPath.substring(resultTableViewPath.indexOf("c:/"));
-
+			const resultTableViewPath:string = path.join(context.extensionPath, 'resultTableWebView.html');
 			fs.readFile(resultTableViewPath, "utf8",
 				(err: any, data: any) => {
 					if (this.resultTablePanel) {
@@ -180,8 +174,10 @@ export class WebViews {
 
 	private revealRangeAndSelection(element: vscode.TextEditor, node: any) {
 		vscode.window.showTextDocument(element.document, vscode.ViewColumn.One, false).then(() => {
-			const start = new vscode.Position(parseInt(node.Line[0]) - 1, parseInt(node.Column[0]) - 1);
-			const end = new vscode.Position(parseInt(node.Line[0]) - 1, parseInt(node.Column[0]) - 1 + parseInt(node.Length[0]));
+			const line = Math.max(0, parseInt(node.Line[0]) - 1);
+			const col = Math.max(0, parseInt(node.Column[0]) - 1);
+			const start = new vscode.Position(line, col);
+			const end = new vscode.Position(line, col + parseInt(node.Length[0]));
 			const range = new vscode.Range(start, end);
 			element.revealRange(range);
 			element.selection = new vscode.Selection(start, end);


### PR DESCRIPTION
Accessing files by URI did not work on Linux or macOS; using file path works.  I have aslo removed Windows-specific code and added some checks to node highlighting: on Linux, some vulnerabilities would have 0 for the column; subtracting 1 from that would cause an exception.   