### PR TITLE
workspace only scan option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cxvscode",
-	"version": "2020.3.1",
+	"version": "2021.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -963,9 +963,9 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-			"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
 			"dev": true,
 			"optional": true
 		},

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "cxvscode",
 	"displayName": "CxVSCode",
 	"description": "CxVSCode is a Checkmarx IDE extension that enables scanning/retrieving results on/from Checkmarx CxSAST",
-	"version": "2020.3.1",
+	"version": "2021.3.1",
 	"publisher": "Checkmarx",
 	"icon": "resources/icons/Checkmarx.png",
 	"license": "SEE LICENSE IN checkmarx-license-terms.md",
@@ -88,6 +88,10 @@
 				"cx.enableScanButtons": {
 					"type": "boolean",
 					"description": "Controls scan any folder/file buttons"
+				},
+				"cx.enableWorkspaceOnlyScan": {
+					"type": "boolean",
+					"description": "Controls Scan menu of only workspace"
 				}
 			}
 		},
@@ -170,15 +174,15 @@
 			},
 			{
 				"command": "Explorer.scanFile",
-				"title": "Scan Current File"
+				"title": "Checkmarx: Scan Current File"
 			},
 			{
 				"command": "Explorer.scanFolder",
-				"title": "Scan Current Folder"
+				"title": "Checkmarx: Scan Current Folder"
 			},
 			{
 				"command": "Explorer.scanWorkspace",
-				"title": "Scan Workspace"
+				"title": "Checkmarx: Scan Workspace"
 			},
 			{
 				"command": "cxportalwin.bindProject",
@@ -307,12 +311,12 @@
 			"explorer/context": [
 				{
 					"command": "Explorer.scanFolder",
-					"when": "explorerResourceIsFolder",
+					"when": "cxSettings.showWorkspaceOnly == false && explorerResourceIsFolder",
 					"group": "Cx"
 				},
 				{
 					"command": "Explorer.scanFile",
-					"when": "!explorerResourceIsFolder",
+					"when": "cxSettings.showWorkspaceOnly == false && !explorerResourceIsFolder",
 					"group": "Cx"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
 				},
 				"cx.enableWorkspaceOnlyScan": {
 					"type": "boolean",
-					"description": "Controls Scan menu of only workspace"
+					"description": "Forces user to always scan at workspace only (Restart required)"
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,21 +59,35 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.window.showWarningMessage('\'Scan Any Folder\' button is disabled');
 		}
 	}));
+if(CxSettings.isWorkspaceOnlyScanEnabled()) {
+	vscode.commands.executeCommand('setContext', 'cxSettings.showWorkspaceOnly', true);
+} else {
+	vscode.commands.executeCommand('setContext', 'cxSettings.showWorkspaceOnly', false);
+}
+
 	context.subscriptions.push(vscode.commands.registerCommand("Explorer.scanFile", async (uri: vscode.Uri) => {
 		const cxServerNode = cxTreeDataProvider.getCurrentServerNode();
+		if(!CxSettings.isWorkspaceOnlyScanEnabled()) {
 		if (cxServerNode) {
 			await cxServerNode.scan(false, uri.fsPath);
 			cxTreeDataProvider.refresh(cxServerNode);
 			cxServerNode.displayCurrentScanedSource();
 		}
+	} else {
+		vscode.window.showWarningMessage('\'Checkmarx: Scan Current Folder\' option is disabled \n. Deselect "Enable Workspace Only Scan" in extension settings and relaunch VSCode"');
+	}
 	}));
 	context.subscriptions.push(vscode.commands.registerCommand("Explorer.scanFolder", async (uri: vscode.Uri) => {
 		const cxServerNode = cxTreeDataProvider.getCurrentServerNode();
+		if(!CxSettings.isWorkspaceOnlyScanEnabled()) {
 		if (cxServerNode) {
 			await cxServerNode.scan(true, uri.fsPath);
 			cxTreeDataProvider.refresh(cxServerNode);
 			cxServerNode.displayCurrentScanedSource();
 		}
+	} else {
+		vscode.window.showWarningMessage('\'Checkmarx: Scan Current File\' option is disabled \n. Deselect "Enable Workspace Only Scan" in extension settings"',  { modal: true });
+	}
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand("Explorer.scanWorkspace", async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,7 @@ if(CxSettings.isWorkspaceOnlyScanEnabled()) {
 			cxServerNode.displayCurrentScanedSource();
 		}
 	} else {
-		vscode.window.showWarningMessage('\'Checkmarx: Scan Current Folder\' option is disabled \n. Deselect "Enable Workspace Only Scan" in extension settings and relaunch VSCode"');
+		vscode.window.showWarningMessage('\'Checkmarx: Scan Current File\' option is disabled \n. Scan can be performed at workspace level only.');
 	}
 	}));
 	context.subscriptions.push(vscode.commands.registerCommand("Explorer.scanFolder", async (uri: vscode.Uri) => {
@@ -86,7 +86,7 @@ if(CxSettings.isWorkspaceOnlyScanEnabled()) {
 			cxServerNode.displayCurrentScanedSource();
 		}
 	} else {
-		vscode.window.showWarningMessage('\'Checkmarx: Scan Current File\' option is disabled \n. Deselect "Enable Workspace Only Scan" in extension settings"',  { modal: true });
+		vscode.window.showWarningMessage('\'Checkmarx: Scan Current Folder\' option is disabled \n. Scan can be performed at workspace level only.');
 	}
 	}));
 

--- a/src/services/CxSettings.ts
+++ b/src/services/CxSettings.ts
@@ -8,6 +8,7 @@ const DEFAULT_FOLDER_EXCLUSIONS: string = "cvs, .svn, .hg, .git, .bzr, bin, obj,
 const CXSERVER: string = 'cx.server';
 const CXQUIET: string = 'cx.quiet';
 const CX_ENABLE_SCAN_BUTTONS: string = 'cx.enableScanButtons'
+const CX_ENABLE_WORKSPACE_ONLY_SCAN: string = 'cx.enableWorkspaceOnlyScan';
 const CX_FOLDER_EXCLUSIONS: string = 'cx.folderExclusions';
 const CX_FILE_EXTENSIONS: string = 'cx.fileExtensions';
 const CX_REPORT_PATH: string = 'cx.reportPath';
@@ -107,6 +108,14 @@ export class CxSettings {
     public static isScanButtonsEnabled(): boolean {
         return vscode.workspace.getConfiguration().get(CX_ENABLE_SCAN_BUTTONS) as boolean;
     }
+ /**
+     * Returns value of the cx.enableWorkspaceOnlyScan setting. The setting controls the scan any file/folder buttons.
+     * Add "cx.enableWorkspaceOnlyScan": true to the settings.json
+     * @returns Value of cx.enableWorkspaceOnlyScan setting
+     */
+  public static isWorkspaceOnlyScanEnabled(): boolean {
+    return vscode.workspace.getConfiguration().get(CX_ENABLE_WORKSPACE_ONLY_SCAN) as boolean;
+}
 
     /**
      * Returns value of the cx.quiet setting. The setting controls the amount of popup messages displayed to the user.


### PR DESCRIPTION
Scenarios tested : 
Scenario 1
------------
1. Go to cx extension settings .
2. Select the checkbox "Enable Workspace Only Scan".
3. Restart VScode.
4. Right click on any folder on explorer. 
5. Verify that "Checkmarx : Scan Workspace" option only visible and when clicked entire workspace scan happens if logged in to SAST
6. Verify that "Checkmarx : Scan Current Folder" menu item is **not** visible when right click on folder in explorer.
7. Verify that "Checkmarx : Scan Current File" menu is **not** visible when right click on any file in explorer.

Scenario 2
------------
1. Go to cx extension settings .
2. Unselect the checkbox "Enable Workspace Only Scan".
3. Restart VScode.
4. Right click on any folder on explorer. 
5. Verify that "Checkmarx : Scan Workspace" option only visible and when clicked entire workspace scan happens if logged in to SAST
6. Verify that "Checkmarx : Scan Current Folder" menu item is also visible when right click on folder in explorer and when clicked scan of that folder happens if logged in to SAST
7. Verify that "Checkmarx : Scan Current File" menu is also visible when right click on any file in explorer and when clicked scan of that file happens if logged in to SAST.

Scenario 3
------------
1. Go to cx extension settings .
2. Unselect the checkbox "Enable Workspace Only Scan".
3. Do not Restart VScode.
4. Right click on any folder on explorer. 
5. Verify that "Checkmarx : Scan Workspace" option only visible and when clicked entire workspace scan happens if logged in to SAST
6. Verify that "Checkmarx : Scan Current Folder" menu item is also visible when right click on folder in explorer and when clicked should give warning pop up message "'Checkmarx: Scan Current Folder' option is disabled . Scan can be performed at workspace level only.
7. Verify that "Checkmarx : Scan Current File" menu is also visible when right click on any file in explorer and when clicked should give warning pop up message "'Checkmarx: Scan Current File" option is disabled . Scan can be performed at workspace level only.