### PR TITLE
changed login option name

### DIFF
--- a/src/model/LoginMethods.ts
+++ b/src/model/LoginMethods.ts
@@ -1,4 +1,4 @@
 export enum LoginMethods {
-    CREDENTIALS = 'Credentials',
+    CREDENTIALS = 'User Name/Password',
     SSO = 'Single Sign On'
 }

--- a/src/model/ServerNode.ts
+++ b/src/model/ServerNode.ts
@@ -158,19 +158,12 @@ File extensions: ${formatOptionalString(sastConfig.fileExtension)}
    
     public async login() {
         try {
-            if (this.loginChecks.isLoggedIn()) {
-                vscode.window.showInformationMessage('You are already logged in!');
-                return;
-            }
-            let loginMethod: string  = LoginMethods.SSO;
-            if(CxSettings.isEnableUserCredentialsLogin())
-            {
-                 loginMethod  = await Utility.showPickString("Select login method", [LoginMethods.CREDENTIALS, LoginMethods.SSO]);
-            }else{
-                loginMethod  =  LoginMethods.SSO;
+                if (this.loginChecks.isLoggedIn()) {
+                    vscode.window.showInformationMessage('You are already logged in!');
+                    return;
+                }
+                let loginMethod = await this.getLoginMethod();
 
-            }
-            if (loginMethod) {
                 if (loginMethod === LoginMethods.CREDENTIALS) {
                     await this.loginWithCredentials();
                     this.log.info('Login successful');
@@ -186,13 +179,24 @@ File extensions: ${formatOptionalString(sastConfig.fileExtension)}
                 }
                 
             }
-        }
+        
         catch (err) {
             this.log.error(err);
             vscode.window.showErrorMessage('Login failed');
         }
     }
 
+    private async getLoginMethod(): Promise<string> {
+        let loginMethod: string;
+        if(CxSettings.isEnableUserCredentialsLogin())
+        {
+             loginMethod  = await Utility.showPickString("Select login method", [LoginMethods.CREDENTIALS, LoginMethods.SSO]);
+        }else{
+            loginMethod  =  LoginMethods.SSO;
+
+        }
+        return loginMethod;
+    }
     private async loginWithCredentials() {
         const cxServer: CxServerSettings = CxSettings.getServer();
         if (cxServer.username.length > 0 && cxServer.password.length > 0) {

--- a/src/model/ServerNode.ts
+++ b/src/model/ServerNode.ts
@@ -162,8 +162,14 @@ File extensions: ${formatOptionalString(sastConfig.fileExtension)}
                 vscode.window.showInformationMessage('You are already logged in!');
                 return;
             }
+            let loginMethod: string  = LoginMethods.SSO;
+            if(CxSettings.isEnableUserCredentialsLogin())
+            {
+                 loginMethod  = await Utility.showPickString("Select login method", [LoginMethods.CREDENTIALS, LoginMethods.SSO]);
+            }else{
+                loginMethod  =  LoginMethods.SSO;
 
-            const loginMethod: string = await Utility.showPickString("Select login method", [LoginMethods.CREDENTIALS, LoginMethods.SSO]);
+            }
             if (loginMethod) {
                 if (loginMethod === LoginMethods.CREDENTIALS) {
                     await this.loginWithCredentials();

--- a/src/services/CxSettings.ts
+++ b/src/services/CxSettings.ts
@@ -12,6 +12,7 @@ const CX_ENABLE_WORKSPACE_ONLY_SCAN: string = 'cx.enableWorkspaceOnlyScan';
 const CX_FOLDER_EXCLUSIONS: string = 'cx.folderExclusions';
 const CX_FILE_EXTENSIONS: string = 'cx.fileExtensions';
 const CX_REPORT_PATH: string = 'cx.reportPath';
+const CX_ENABLE_USER_CREDENTIALS_LOGIN: string = 'cx.enableUserCredentialsLogin';
 
 export interface CxServerSettings {
     url: string;
@@ -117,6 +118,15 @@ export class CxSettings {
     return vscode.workspace.getConfiguration().get(CX_ENABLE_WORKSPACE_ONLY_SCAN) as boolean;
 }
 
+
+ /**
+     * Returns value of the cx.enableUserCredentialsLogin setting. The setting controls the User credentials login.
+     * Add "cx.enableUserCredentialsLogin": false to the settings.json
+     * @returns Value of cx.enableUserCredentialsLogin setting
+     */
+  public static isEnableUserCredentialsLogin(): boolean {
+    return vscode.workspace.getConfiguration().get(CX_ENABLE_USER_CREDENTIALS_LOGIN) as boolean;
+}
     /**
      * Returns value of the cx.quiet setting. The setting controls the amount of popup messages displayed to the user.
      * Add "cx.quiet": true to the settings.json


### PR DESCRIPTION
(Fixed [AB#2666](https://dev.azure.com/CxSDLC/fc0b9449-79c8-4ff2-bd04-b9e18cf01a53/_workitems/edit/2666))

1) When user selects "Enable User Credentials Login." from setting page then only user will get both login options
        a) User Name/Password
        b) SSO Login
2) By default "Enable User Credentials Login."  option will be false. If this setting is not selected then by default only SSO login option will be enabled and user will not be prompted to select login method.