### PR TITLE
Added SSL certificate path fields in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,10 @@
 				"cx.enableUserCredentialsLogin": {
 					"type": "boolean",
 					"description": "Enable User Credentials Login."
+				},
+				"cx.sslCertificatePath": {
+					"type": "string",
+					"description": "SSL certificate path."
 				}
 			}
 		},

--- a/src/model/ServerNode.ts
+++ b/src/model/ServerNode.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as url from "url";
 import { INode } from "../interface/INode";
-import { Logger,ScanResults,CxClient,ScanConfig ,SastConfig,TeamApiClient,HttpClient, AuthSSODetails} from "@checkmarx/cx-common-js-client";
+import { Logger,ScanResults,CxClient,ScanConfig ,SastConfig,TeamApiClient,HttpClient, AuthSSODetails,ProxyConfig} from "@checkmarx/cx-common-js-client";
 import { ProjectNode } from "./ProjectNode";
 import { ScanNode } from "./ScanNode";
 import { Utility } from "../utils/util";
@@ -31,6 +31,7 @@ export class ServerNode implements INode {
     private authSSODetails: AuthSSODetails | any;
     private storageManager :  SessionStorageService;
     private loginChecks: LoginChecks | any;
+    private proxyConfig : ProxyConfig | any;
 
     constructor(public readonly sastUrl: string, private readonly alias: string, private readonly log: Logger,private readonly context: vscode.ExtensionContext) {
         this.username = '';
@@ -46,7 +47,7 @@ export class ServerNode implements INode {
 
         const baseUrl = url.resolve(this.sastUrl, 'CxRestAPI/');
 
-        this.httpClient = new HttpClient(baseUrl, "Visual-Studio-Code","", this.log);
+        this.httpClient = new HttpClient(baseUrl, "Visual-Studio-Code","", this.log,this.proxyConfig,CxSettings.getSSLCertPath());
 
         this.storageManager = new SessionStorageService(context.workspaceState);
 

--- a/src/services/CxSettings.ts
+++ b/src/services/CxSettings.ts
@@ -13,6 +13,7 @@ const CX_FOLDER_EXCLUSIONS: string = 'cx.folderExclusions';
 const CX_FILE_EXTENSIONS: string = 'cx.fileExtensions';
 const CX_REPORT_PATH: string = 'cx.reportPath';
 const CX_ENABLE_USER_CREDENTIALS_LOGIN: string = 'cx.enableUserCredentialsLogin';
+const CX_SSL_CERT_PATH: string = 'cx.sslCertificatePath';
 
 export interface CxServerSettings {
     url: string;
@@ -126,6 +127,15 @@ export class CxSettings {
      */
   public static isEnableUserCredentialsLogin(): boolean {
     return vscode.workspace.getConfiguration().get(CX_ENABLE_USER_CREDENTIALS_LOGIN) as boolean;
+}
+
+ /**
+     * Returns value of the cx.sslCertPath setting. The setting value will be used as certifcate path 
+     * is used for SSL connection.
+     * @returns Value of cx.sslCertPath setting
+     */
+  public static getSSLCertPath(): string {
+    return vscode.workspace.getConfiguration().get(CX_SSL_CERT_PATH) as string;
 }
     /**
      * Returns value of the cx.quiet setting. The setting controls the amount of popup messages displayed to the user.


### PR DESCRIPTION
(Fixed [AB#2686](https://dev.azure.com/CxSDLC/fc0b9449-79c8-4ff2-bd04-b9e18cf01a53/_workitems/edit/2686))

User will be able to set SSL certificate path in VSCode extnsion settings
once it is set then code will use this certificate for connection