### PR TITLE
Added functionality of avoid duplicate project scans in queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,10 @@
 				"cx.mandatoryComment": {
 					"type": "boolean",
 					"description": "This will make providing comments mandatory while changing result state of vulnerabilitie(s)."
+				},
+				"cx.avoidDuplicateProjectScansInQueue": {
+					"type": "boolean",
+					"description": "Avoid duplicate project scans in queue."
 				}
 			}
 		},

--- a/src/model/ServerNode.ts
+++ b/src/model/ServerNode.ts
@@ -699,7 +699,7 @@ File extensions: ${formatOptionalString(sastConfig.fileExtension)}
                 isPublic: !isPrivate,
                 postScanActionName: "",
                 postScanActionId: -1,
-                avoidDuplicateProjectScans:false,
+                avoidDuplicateProjectScans: CxSettings.getAvoidDuplicateProjectScansInQueueFlag(),
                 projectCustomFields: "",
                 customFields: "",
                 failBuildForNewVulnerabilitiesEnabled: false,
@@ -709,7 +709,6 @@ File extensions: ${formatOptionalString(sastConfig.fileExtension)}
                 // This gets used only in ADO plugin. adding here to resolve compileation issue.
                 cacert_chainFilePath: ""
             };
-
             let proxyResult: ProxyConfig ={
                 proxyHost: '',
                 proxyPass:  '',

--- a/src/services/CxSettings.ts
+++ b/src/services/CxSettings.ts
@@ -15,6 +15,7 @@ const CX_REPORT_PATH: string = 'cx.reportPath';
 const CX_ENABLE_USER_CREDENTIALS_LOGIN: string = 'cx.enableUserCredentialsLogin';
 const CX_SSL_CERT_PATH: string = 'cx.sslCertificatePath';
 const CX_ENABLE_MANDATORY_COMMENT_ON_RESULT_STATE_CHANGE: string = 'cx.mandatoryComment';
+const CX_AVOID_DUPLICATE_PROJECT_SCANS_IN_QUEUE  : string = 'cx.avoidDuplicateProjectScansInQueue';
 
 export interface CxServerSettings {
     url: string;
@@ -212,6 +213,24 @@ export class CxSettings {
      */
     public static getMandatoryCommentFlag(): boolean {
         return vscode.workspace.getConfiguration().get(CX_ENABLE_MANDATORY_COMMENT_ON_RESULT_STATE_CHANGE) as boolean;
+    }
+
+    /**
+     * Stores mandatory comment in the settings.json
+     *
+     * @param isEnableAvoidDuplicateProjectScansInQueue flag represents Avoid duplicate project scans in queue
+     */
+    public static async updateAvoidDuplicateProjectScansInQueueFlag(isEnableAvoidDuplicateProjectScansInQueue: boolean) {
+        await vscode.workspace.getConfiguration().update(CX_ENABLE_MANDATORY_COMMENT_ON_RESULT_STATE_CHANGE, isEnableAvoidDuplicateProjectScansInQueue);
+    }
+
+    /**
+     * Returns the current value of cx.avoidDuplicateProjectScansInQueue setting
+     *
+     * @returns Avoid duplicate project scans in queue as boolean
+     */
+    public static getAvoidDuplicateProjectScansInQueueFlag(): boolean {
+        return vscode.workspace.getConfiguration().get(CX_AVOID_DUPLICATE_PROJECT_SCANS_IN_QUEUE) as boolean;
     }
 
     public static async updateReportPath(reportPath: string) {


### PR DESCRIPTION
**Added functionality of avoid duplicate project scans in queue**

**Test Case 1**
- Go to checkmarx extension -> settings -> mark Avoid Duplicate Project Scans In Queue as checked
- Create a new Project (Project1) and run a scan 
- wait till the scan complete
- Once the scan is completed create new 2 scans one by one (full scan \ incremental scan)
- 2nd scan will not created -> will get message if 1st scan is in queue -> Project scan is already in progress.


**Test Case 2**
- Go to checkmarx extension -> settings -> mark Avoid Duplicate Project Scans In Queue as unchecked
- Create a new Project (Project2) and run a scan 
- wait till the scan complete
- Once the scan completed create new 2 scans one by one (full scan \ incremental scan)
- Both scan created successfully


