### PR TITLE
Plug 1446

### DIFF
--- a/resultTableWebView.html
+++ b/resultTableWebView.html
@@ -59,6 +59,7 @@ table-layout: fixed;
     </div>
 
     <script>
+        var resultStates;
         function getPathId(){
             if(!$("td").hasClass("editComment")){
                 $("td").addClass("editComment");
@@ -140,20 +141,20 @@ table-layout: fixed;
         }
 
         const vscode = acquireVsCodeApi();
-        const stateDictionary = {
-            '0': 'To Verify',
-            '1': 'Not Exploitable',
-            '2': 'Confirmed',
-            '3': 'Urgent',
-            '4': 'Proposed Not Exploitable'
-        };
-		const stateOrdinalDictionary = {
-            'To Verify':'0',
-            'Not Exploitable':'1' ,
-            'Confirmed':'2',
-            'Urgent':'3',
-            'Proposed Not Exploitable':'4' 
-        };
+        // const stateDictionary = {
+        //     '0': 'To Verify',
+        //     '1': 'Not Exploitable',
+        //     '2': 'Confirmed',
+        //     '3': 'Urgent',
+        //     '4': 'Proposed Not Exploitable'
+        // };
+		// const stateOrdinalDictionary = {
+        //     'To Verify':'0',
+        //     'Not Exploitable':'1' ,
+        //     'Confirmed':'2',
+        //     'Urgent':'3',
+        //     'Proposed Not Exploitable':'4' 
+        // };
         // Get messages
         window.addEventListener('message', event => {
             const message = event.data; // The JSON data our extension sent
@@ -223,8 +224,14 @@ table-layout: fixed;
             $("#list").append("<table >");
 			var selectHTML = "<tr style='background:rgba(29,150,178,1)'><td colspan='4'>" +"<select id='resultStateDropDownList'>";
                 selectHTML = selectHTML + "<option value=''>Result State</option>";
-            for (i = 0; i < message.resultStates.states.length; i = i + 1) {
-                selectHTML += "<option value='" + message.resultStates.states[i].name + "'>" + message.resultStates.states[i].name + "</option>";
+            resultStates = message.resultStates.states;
+            for (i = 0; i < resultStates.length; i = i + 1) {
+                if(!message.manageResultsExploitabel)
+                {
+                    if(resultStates[i].id != '1' )
+                        selectHTML += "<option value='" + i + "'>" + resultStates[i].name + "</option>";
+                }
+                else selectHTML += "<option value='" + i + "'>" + resultStates[i].name + "</option>";
             }
             selectHTML +=  "</select></td>";
             selectHTML += "<td colspan='6'> <select id='assignUserDropDownList'> <option>Assign User</option>";
@@ -310,7 +317,7 @@ table-layout: fixed;
                 $("#list").append("<tr style='cursor:pointer; vertical-align:top'" + " id='result" + i + "' >" +
 					"<td class='check'> <input type ='checkbox' id= 'checkbox-"+i+ "'name = 'querySelected' value = '"+result.Path[0].$.PathId+"'>"+"</td>"+
                     "<td class='id' id='pathId-" + i + "'  title='"+result.Path[0].$.PathId+"'>" + result.Path[0].$.PathId + "</td>" +
-                    "<td class='state' title='"+stateDictionary[result.$.state]+"'>" + stateDictionary[result.$.state] + "</td>" +
+                    "<td class='state' title='"+ resultStates[result.$.state].name +"'>" + resultStates[result.$.state].name + "</td>" +
                     "<td class='status' title='"+result.$.Status+"'>" + result.$.Status + "</td>" +
                     "<td class='name'  title='"+message.$.name+"'>" + message.$.name + "</td>" +
                     "<td class='sourcefolder'  title='"+srcFileName.slice(0,srcFileName.lastIndexOf("/"))+"'>" + srcFileName.slice(0,srcFileName.lastIndexOf("/")) + "</td>" +
@@ -388,7 +395,6 @@ table-layout: fixed;
                         var selectedResultState = $('#resultStateDropDownList option:selected').val();
                         
                         if(selectedResultState != ''){                            
-                        selectedResultState = stateOrdinalDictionary[selectedResultState];
                         vscode.postMessage({command: 'resultstateChangeEvent', bulkComment: bulkInputComment, resultStateTobeChange: selectedResultState, data: selectedQueryNodes});
                         }
                         else{                          
@@ -482,7 +488,6 @@ table-layout: fixed;
 			$('#resultStateDropDownList').on('change', function() 
             {
                 var selectedResultState = $('#resultStateDropDownList option:selected').val();
-                selectedResultState = stateOrdinalDictionary[selectedResultState];
                 var selectedQueryNodes = [];
                 $.each($("input[name='querySelected']:checked"), function () 
                     {

--- a/resultTableWebView.html
+++ b/resultTableWebView.html
@@ -225,13 +225,35 @@ table-layout: fixed;
 			var selectHTML = "<tr style='background:rgba(29,150,178,1)'><td colspan='4'>" +"<select id='resultStateDropDownList'>";
                 selectHTML = selectHTML + "<option value=''>Result State</option>";
             resultStates = message.resultStates.states;
+            
             for (i = 0; i < resultStates.length; i = i + 1) {
-                if(!message.manageResultsExploitabel)
-                {
-                    if(resultStates[i].id != '1' )
-                        selectHTML += "<option value='" + i + "'>" + resultStates[i].name + "</option>";
+                switch(resultStates[i].name) {
+                    case "To Verify":
+                        if(message.manageResultsToVerify) 
+                            selectHTML +="<option value='" + i + "'>" + resultStates[i].name + "</option>";
+                        break;
+                    case "Not Exploitable":
+                        if(message.manageResultsNotExploitabel) 
+                            selectHTML +="<option value='" + i + "'>" + resultStates[i].name + "</option>";
+                        break;
+                    case "Confirmed":
+                        if(message.manageResultsConfirmed) 
+                            selectHTML +="<option value='" + i + "'>" + resultStates[i].name + "</option>";
+                        break;
+                    case "Urgent":
+                        if(message.manageResultsUrgent) 
+                            selectHTML +="<option value='" + i + "'>" + resultStates[i].name + "</option>";
+                        break;
+                    case "Proposed Not Exploitable":
+                        if(message.manageResultsProposedNotExploitable) 
+                            selectHTML +="<option value='" + i + "'>" + resultStates[i].name + "</option>";
+                        break;
+                    case "Accepted":
+                        if(message.manageResultsAccepted) 
+                            selectHTML +="<option value='" + i + "'>" + resultStates[i].name + "</option>";
+                        break;
+                    default:
                 }
-                else selectHTML += "<option value='" + i + "'>" + resultStates[i].name + "</option>";
             }
             selectHTML +=  "</select></td>";
             selectHTML += "<td colspan='6'> <select id='assignUserDropDownList'> <option>Assign User</option>";

--- a/resultTableWebView.html
+++ b/resultTableWebView.html
@@ -225,34 +225,11 @@ table-layout: fixed;
 			var selectHTML = "<tr style='background:rgba(29,150,178,1)'><td colspan='4'>" +"<select id='resultStateDropDownList'>";
                 selectHTML = selectHTML + "<option value=''>Result State</option>";
             resultStates = message.resultStates.states;
-            
-            for (i = 0; i < resultStates.length; i = i + 1) {
-                switch(resultStates[i].name) {
-                    case "To Verify":
-                        if(message.manageResultsToVerify) 
-                            selectHTML +="<option value='" + i + "'>" + resultStates[i].name + "</option>";
-                        break;
-                    case "Not Exploitable":
-                        if(message.manageResultsNotExploitabel) 
-                            selectHTML +="<option value='" + i + "'>" + resultStates[i].name + "</option>";
-                        break;
-                    case "Confirmed":
-                        if(message.manageResultsConfirmed) 
-                            selectHTML +="<option value='" + i + "'>" + resultStates[i].name + "</option>";
-                        break;
-                    case "Urgent":
-                        if(message.manageResultsUrgent) 
-                            selectHTML +="<option value='" + i + "'>" + resultStates[i].name + "</option>";
-                        break;
-                    case "Proposed Not Exploitable":
-                        if(message.manageResultsProposedNotExploitable) 
-                            selectHTML +="<option value='" + i + "'>" + resultStates[i].name + "</option>";
-                        break;
-                    case "Accepted":
-                        if(message.manageResultsAccepted) 
-                            selectHTML +="<option value='" + i + "'>" + resultStates[i].name + "</option>";
-                        break;
-                    default:
+            if(resultStates.length > 0)
+            {
+                for (i = 0; i < resultStates.length; i = i + 1) {
+                    if(resultStates[i].isUserHavePermission)
+                         selectHTML +="<option value='" + resultStates[i].id + "'>" + resultStates[i].name + "</option>";
                 }
             }
             selectHTML +=  "</select></td>";
@@ -336,10 +313,11 @@ table-layout: fixed;
                     comment4 = rest4;
                 }
             
+                let stateName=  resultStates[result.$.state]? resultStates[result.$.state].name :'';
                 $("#list").append("<tr style='cursor:pointer; vertical-align:top'" + " id='result" + i + "' >" +
 					"<td class='check'> <input type ='checkbox' id= 'checkbox-"+i+ "'name = 'querySelected' value = '"+result.Path[0].$.PathId+"'>"+"</td>"+
                     "<td class='id' id='pathId-" + i + "'  title='"+result.Path[0].$.PathId+"'>" + result.Path[0].$.PathId + "</td>" +
-                    "<td class='state' title='"+ resultStates[result.$.state].name +"'>" + resultStates[result.$.state].name + "</td>" +
+                    "<td class='state' title='"+ stateName  +"'>" + stateName  + "</td>" +
                     "<td class='status' title='"+result.$.Status+"'>" + result.$.Status + "</td>" +
                     "<td class='name'  title='"+message.$.name+"'>" + message.$.name + "</td>" +
                     "<td class='sourcefolder'  title='"+srcFileName.slice(0,srcFileName.lastIndexOf("/"))+"'>" + srcFileName.slice(0,srcFileName.lastIndexOf("/")) + "</td>" +
@@ -415,15 +393,17 @@ table-layout: fixed;
                     });                                       
                     if(mandatoryComment){
                         var selectedResultState = $('#resultStateDropDownList option:selected').val();
+
+                        var selectedResultStateText = $('#resultStateDropDownList option:selected').text();
                         
-                        if(selectedResultState != ''){                            
-                        vscode.postMessage({command: 'resultstateChangeEvent', bulkComment: bulkInputComment, resultStateTobeChange: selectedResultState, data: selectedQueryNodes});
+                        if(selectedResultState != ''){                         
+                        vscode.postMessage({command: 'resultstateChangeEvent', bulkComment: bulkInputComment, resultStateTobeChange: selectedResultState, data: selectedQueryNodes, resultStateText : selectedResultStateText});
                         }
                         else{                          
                         vscode.postMessage({command: 'bulkComments', bulkComment: bulkInputComment, data: selectedQueryNodes});
                         }
                     }
-                    else{                        
+                    else{                      
                         vscode.postMessage({command: 'bulkComments', bulkComment: bulkInputComment, data: selectedQueryNodes});
                     }
                 }
@@ -510,16 +490,16 @@ table-layout: fixed;
 			$('#resultStateDropDownList').on('change', function() 
             {
                 var selectedResultState = $('#resultStateDropDownList option:selected').val();
+                var selectedResultStateText = $('#resultStateDropDownList option:selected').text();
                 var selectedQueryNodes = [];
                 $.each($("input[name='querySelected']:checked"), function () 
                     {
                         selectedQueryNodes.push($(this).val());
                     });
-
                 if(mandatoryComment)
                     bulkEnterComment();
                 else              
-                    vscode.postMessage({command: 'resultstateChangeEvent', resultStateTobeChange: selectedResultState, data: selectedQueryNodes});
+                    vscode.postMessage({command: 'resultstateChangeEvent', resultStateTobeChange: selectedResultState, data: selectedQueryNodes, resultStateText : selectedResultStateText});
                 });
 				
             $("#list").append("</table></body></html>");

--- a/src/model/ServerNode.ts
+++ b/src/model/ServerNode.ts
@@ -167,7 +167,7 @@ File extensions: ${formatOptionalString(sastConfig.fileExtension)}
                 this.log.info('Login successful');
                 vscode.window.showInformationMessage('Login successful');
                 this.storageManager.setValue<string>(SSOConstants.ACCESS_TOKEN, this.httpClient.accessToken);
-
+                await this.httpClient.getPermissionDetailsUsingJwtDecode(); 
                 if (this.isBoundToProject()) 
                 {
                     await this.retrieveLatestResults();
@@ -176,7 +176,7 @@ File extensions: ${formatOptionalString(sastConfig.fileExtension)}
             else 
             {
                 await this.ssoLogin();
-            }         
+            }      
         }    
         catch (err) {
             this.log.error(err);
@@ -227,7 +227,7 @@ File extensions: ${formatOptionalString(sastConfig.fileExtension)}
                 let authURL: string = await this.httpClient.getAuthorizationCodeURL(this.authSSODetails);
                 
                 // Open browser windows for SAST server login for SSO
-                vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(authURL));
+                vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(authURL));  
                
         }catch (err) {
             this.log.error(err);
@@ -253,7 +253,7 @@ File extensions: ${formatOptionalString(sastConfig.fileExtension)}
 
             /* Setting access token in context */ 
             this.storageManager.setValue<string>(SSOConstants.ACCESS_TOKEN, access_token);
-
+            await this.httpClient.getPermissionsFromUserInfo(); 
             if (this.isBoundToProject()) {
                 await this.retrieveLatestResults();
             }

--- a/src/services/WebViews.ts
+++ b/src/services/WebViews.ts
@@ -130,14 +130,9 @@ export class WebViews {
 			let resultStatesWithPermissions: ResultStateDetails[] = await this.httpClient.getRequest(`sast/resultStates`);
 			for(let state of resultStates.states )
 			{
-				let permission : string = resultStatesWithPermissions.find((abc) => abc.id === state.id)?.permission || '';
+				let permission : string = resultStatesWithPermissions.find((abc) => abc.id === state.id)?.permission ?? '';
 				if(permission) state.isUserHavePermission = await this.httpClient.validateUserPermission(permission);
 			}
-			// for(let i=0;i<resultStates.states.length ;i++)
-			// {
-			// 	let permission : string = resultStatesWithPermissions.find((abc) => abc.id === resultStates.states[i].id)?.permission || '';
-			// 	if(permission) resultStates.states[i].isUserHavePermission = await this.httpClient.validateUserPermission(permission);
-			// }
 		}
 		catch(e){
 			if (e.status == 404) {

--- a/src/services/WebViews.ts
+++ b/src/services/WebViews.ts
@@ -94,7 +94,12 @@ export class WebViews {
 			const userInfo = await this.httpClient.getPermissionsFromUserInfo();
 			
 			query.resultStates = resultStates;
-			query.manageResultsExploitabel = userInfo.manageResultsExploitabel;
+			query.manageResultsNotExploitabel = userInfo.manageResultsNotExploitabel;
+			query.manageResultsToVerify = userInfo.manageResultsToVerify;
+			query.manageResultsConfirmed = userInfo.manageResultsConfirmed;
+			query.manageResultsUrgent = userInfo.manageResultsUrgent;
+			query.manageResultsProposedNotExploitable = userInfo.manageResultsProposedNotExploitable;
+			query.manageResultsAccepted = userInfo.manageResultsAccepted;
 
 			let usersResponse = await this.httpClient.getRequest(`auth/AssignableUsers`);
 			let usersList: string[] = [];

--- a/src/services/WebViews.ts
+++ b/src/services/WebViews.ts
@@ -7,7 +7,24 @@ import { SessionStorageService } from './sessionStorageService';
 import { SSOConstants } from '../model/ssoConstant';
 import { LoginChecks } from './loginChecks';
 import { CxSettings } from "./CxSettings";
+import { promises } from 'dns';
 
+interface ResultStateApiResponse {
+	states: { id: number; name: string, isUserHavePermission:boolean }[]
+}
+
+interface ResultStateDetails {
+	id: number;
+	names: Name[];
+	permission: string;
+  }
+
+  interface Name {
+	languageId: number;
+	name: string;
+	isConstant: boolean;
+  }
+  
 
 export class WebViews {
 
@@ -89,17 +106,7 @@ export class WebViews {
 			query.clickedRow=0;
 			this.queryForDescription=query;
 
-			const resultStates: string[] = await this.httpClient.getRequest(`sast/result-states`);
-			
-			const userInfo = await this.httpClient.getPermissionsFromUserInfo();
-			
-			query.resultStates = resultStates;
-			query.manageResultsNotExploitabel = userInfo.manageResultsNotExploitabel;
-			query.manageResultsToVerify = userInfo.manageResultsToVerify;
-			query.manageResultsConfirmed = userInfo.manageResultsConfirmed;
-			query.manageResultsUrgent = userInfo.manageResultsUrgent;
-			query.manageResultsProposedNotExploitable = userInfo.manageResultsProposedNotExploitable;
-			query.manageResultsAccepted = userInfo.manageResultsAccepted;
+			query.resultStates = await this.getResultStateWithPermission();
 
 			let usersResponse = await this.httpClient.getRequest(`auth/AssignableUsers`);
 			let usersList: string[] = [];
@@ -117,6 +124,26 @@ export class WebViews {
 
 	}
 
+	async getResultStateWithPermission()
+	{
+		const resultStates: ResultStateApiResponse = await this.httpClient.getRequest(`sast/result-states`);
+		try {
+			let resultStatesWithPermissions: ResultStateDetails[] = await this.httpClient.getRequest(`sast/resultStates`);
+			for(let i=0;i<resultStates.states.length ;i++)
+			{
+				let permission : string | any= resultStatesWithPermissions.find((abc) => abc.id === resultStates.states[i].id)?.permission;
+				if(permission) resultStates.states[i].isUserHavePermission = await this.httpClient.validateUserPermission(permission);
+			}
+		}
+		catch(e){
+			if (e.status == 404) {
+				resultStates.states.forEach( b => b.isUserHavePermission = true);
+			}
+		}
+		
+		return resultStates;
+	}
+	
 	private createAttackVectorWebView(context: vscode.ExtensionContext) {
 		this.attackVectorPanel = vscode.window.createWebviewPanel(
 			'attackVector',
@@ -186,9 +213,9 @@ export class WebViews {
 									switch (message.command) {
 										case 'resultstateChangeEvent':
 											if(message.bulkComment)
-												this.resultStateChanged(message.bulkComment, message.resultStateTobeChange, message.data);
+												this.resultStateChanged(message.bulkComment, message.resultStateTobeChange, message.data,message.resultStateText);
 											else
-												this.resultStateChanged('', message.resultStateTobeChange, message.data);
+												this.resultStateChanged('', message.resultStateTobeChange, message.data,message.resultStateText);
 										 	 return;
 										case 'onClick':
 											this.updateShortDescriptionForResult(message);
@@ -427,7 +454,7 @@ export class WebViews {
 		
 		}	
 	}
-	private async resultStateChanged(bulkComment: any, selectedResultState: any, rows: any){
+	private async resultStateChanged(bulkComment: any, selectedResultState: any, rows: any,resultStateText :any){
 		let scanId = this.scanNode.scanId;
 		let nodes = this.queryNode.Result;
 
@@ -435,27 +462,37 @@ export class WebViews {
 
 		const request = bulkComment === '' ? {"state" : selectedResultState} : {"state" : selectedResultState,"comment" : bulkComment};
 		//The below for loop updates the result state
+		var isErrorCatched = false;
 		for (var i = 0; i < rows.length; i++) {
 			var pathId = rows[i];
-			for (let nodeCtr = 0; nodeCtr < nodes.length; nodeCtr++) { 
-				if( pathId == nodes[nodeCtr].Path[0].$.PathId) {
-					
-					try {
-						await this.httpClient.patchRequest(`sast/scans/${scanId}/results/${pathId}`, request);
-						nodes[nodeCtr].$.state = selectedResultState;	
-						nodes[nodeCtr].$.Remark = bulkComment === '' ? nodes[nodeCtr].$.Remark  : `New Comment,${bulkComment}\r\n${nodes[nodeCtr].$.Remark}`;					
-					} 
-					catch (err) {
-						if (err.status == 404) {
-							this.log.error('This operation is not supported with CxSAST version in use.');
-						}
-						//in case sast server flag is true but extension flag is false then updating result state throws error response with 49797 code. This if block tackles the error response.
-						if(err.response.body.messageCode == 49797)
-						{
-							this.log.error("A comment is required while updating result state flag.");
-							this.queryNode.mandatoryCommentErrorMessage = "Checkmarx SAST Server mandates comments while changing state of vulnerabilities. Enable 'Mandatory Comments' setting in Extension settings in Visual Source Code.";
-						}
-					}	
+			if(!isErrorCatched)
+			{
+				for (let nodeCtr = 0; nodeCtr < nodes.length; nodeCtr++) { 
+					if( pathId == nodes[nodeCtr].Path[0].$.PathId) {
+						
+						try {
+							await this.httpClient.patchRequest(`sast/scans/${scanId}/results/${pathId}`, request);
+							nodes[nodeCtr].$.state = selectedResultState;	
+							nodes[nodeCtr].$.Remark = bulkComment === '' ? nodes[nodeCtr].$.Remark  : `New Comment,${bulkComment}\r\n${nodes[nodeCtr].$.Remark}`;					
+						} 
+						catch (err) {
+							isErrorCatched = true;
+							if (err.status == 404) {
+								this.log.error('This operation is not supported with CxSAST version in use.');
+							}
+							else if (err.status == 403) {
+								this.log.error('You are not authorized to mark the selected vulnerability result as  ' + resultStateText);
+								vscode.window.showErrorMessage('You are not authorized to mark the selected vulnerability result as  ' + resultStateText);
+								break;
+							}
+							//in case sast server flag is true but extension flag is false then updating result state throws error response with 49797 code. This if block tackles the error response.
+							if(err.response.body.messageCode == 49797)
+							{
+								this.log.error("A comment is required while updating result state flag.");
+								this.queryNode.mandatoryCommentErrorMessage = "Checkmarx SAST Server mandates comments while changing state of vulnerabilities. Enable 'Mandatory Comments' setting in Extension settings in Visual Source Code.";
+							}
+						}	
+					}
 				}
 			}
 		}

--- a/src/services/WebViews.ts
+++ b/src/services/WebViews.ts
@@ -130,7 +130,7 @@ export class WebViews {
 			let resultStatesWithPermissions: ResultStateDetails[] = await this.httpClient.getRequest(`sast/resultStates`);
 			for(let i=0;i<resultStates.states.length ;i++)
 			{
-				let permission : string | any= resultStatesWithPermissions.find((abc) => abc.id === resultStates.states[i].id)?.permission;
+				let permission : string = resultStatesWithPermissions.find((abc) => abc.id === resultStates.states[i].id)?.permission || '';
 				if(permission) resultStates.states[i].isUserHavePermission = await this.httpClient.validateUserPermission(permission);
 			}
 		}

--- a/src/services/WebViews.ts
+++ b/src/services/WebViews.ts
@@ -7,7 +7,6 @@ import { SessionStorageService } from './sessionStorageService';
 import { SSOConstants } from '../model/ssoConstant';
 import { LoginChecks } from './loginChecks';
 import { CxSettings } from "./CxSettings";
-import { promises } from 'dns';
 
 interface ResultStateApiResponse {
 	states: { id: number; name: string, isUserHavePermission:boolean }[]
@@ -462,7 +461,7 @@ export class WebViews {
 
 		const request = bulkComment === '' ? {"state" : selectedResultState} : {"state" : selectedResultState,"comment" : bulkComment};
 		//The below for loop updates the result state
-		var isErrorCatched = false;
+		let isErrorCatched = false;
 		for (var i = 0; i < rows.length; i++) {
 			var pathId = rows[i];
 			if(!isErrorCatched)

--- a/src/services/WebViews.ts
+++ b/src/services/WebViews.ts
@@ -128,11 +128,16 @@ export class WebViews {
 		const resultStates: ResultStateApiResponse = await this.httpClient.getRequest(`sast/result-states`);
 		try {
 			let resultStatesWithPermissions: ResultStateDetails[] = await this.httpClient.getRequest(`sast/resultStates`);
-			for(let i=0;i<resultStates.states.length ;i++)
+			for(let state of resultStates.states )
 			{
-				let permission : string = resultStatesWithPermissions.find((abc) => abc.id === resultStates.states[i].id)?.permission || '';
-				if(permission) resultStates.states[i].isUserHavePermission = await this.httpClient.validateUserPermission(permission);
+				let permission : string = resultStatesWithPermissions.find((abc) => abc.id === state.id)?.permission || '';
+				if(permission) state.isUserHavePermission = await this.httpClient.validateUserPermission(permission);
 			}
+			// for(let i=0;i<resultStates.states.length ;i++)
+			// {
+			// 	let permission : string = resultStatesWithPermissions.find((abc) => abc.id === resultStates.states[i].id)?.permission || '';
+			// 	if(permission) resultStates.states[i].isUserHavePermission = await this.httpClient.validateUserPermission(permission);
+			// }
 		}
 		catch(e){
 			if (e.status == 404) {

--- a/src/services/WebViews.ts
+++ b/src/services/WebViews.ts
@@ -90,7 +90,11 @@ export class WebViews {
 			this.queryForDescription=query;
 
 			const resultStates: string[] = await this.httpClient.getRequest(`sast/result-states`);
+			
+			const userInfo = await this.httpClient.getPermissionsFromUserInfo();
+			
 			query.resultStates = resultStates;
+			query.manageResultsExploitabel = userInfo.manageResultsExploitabel;
 
 			let usersResponse = await this.httpClient.getRequest(`auth/AssignableUsers`);
 			let usersList: string[] = [];


### PR DESCRIPTION
**Changes** 
- When login with SSO -> used API connect/userinfo to fetch permissions
- when login with uname_password - using jwt decode to fetch permissions
- Removed hardcode values of result states
- Fetched result state dynamically and shown according to permission

Test below cases login with SSO and username_password both
- Create a new Role R1
- Create a new user with R1 roles

**Test Case 1**
- Role R1 - uncheck permission of set-result-state-toverify.
- login with the VS code plugin and check the result state available in the result state table
Expected output - To Verify option not available in Result state dropdown
- Do similar things for Confirmed, Urgent, Not exploitable, Proposed not exploitable
- update vulnerability states of any
- Check with different language 


**Test Case 2**
- Create a custom state as per documentation
https://checkmarx.atlassian.net/wiki/spaces/KC/pages/5982847752/Adding+Custom+Result+States
- Provide newly created states permission to the user 
- log in with the VS plugin and check the result state available in the result state table
Expected output - newly created custom field display in result state dropdown
- update the vulnerability states of any
- remove permission of newly created custom states
- login with the VS plugin and check result state is available in the result state table or not
Expected output - option not available in Result state dropdown



**Test Case 3**
- Test all this with latest SAST 9.4,9.5,9.6.

**Test Case 4**
- For SAST 9.4 API is not available - sast/resultStates
- If user not have permissions and try to update selected vulnarabilty result state then it will return error message -You are not authorized to mark the selected vulnerability result as  